### PR TITLE
Add tests for API routes and components

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+import os
+import sys
+import json
+import shutil
+import types
+import pytest
+import pathlib
+
+base_dir = pathlib.Path(__file__).resolve().parent.parent
+src_dir = base_dir / 'src'
+sys.path.insert(0, str(src_dir))
+
+if 'pyaudio' not in sys.modules:
+    dummy = types.ModuleType('pyaudio')
+    dummy.paInt16 = 8
+
+    class PyAudio:
+        def open(self, *args, **kwargs):
+            class Stream:
+                def read(self, *a, **kw):
+                    return b''
+                def stop_stream(self):
+                    pass
+                def close(self):
+                    pass
+            return Stream()
+
+        def get_sample_size(self, *args):
+            return 2
+
+        def terminate(self):
+            pass
+
+    dummy.PyAudio = PyAudio
+    sys.modules['pyaudio'] = dummy
+
+
+
+@pytest.fixture(scope="session", autouse=True)
+def prepare_config():
+    """Create keila_config.json from example for tests."""
+    base_dir = os.path.dirname(os.path.dirname(__file__))
+    src_dir = os.path.join(base_dir, 'src')
+    example = os.path.join(src_dir, 'keila_config,example.json')
+    config = os.path.join(src_dir, 'keila_config.json')
+    shutil.copy(example, config)
+    os.environ.setdefault('KEILA_VERSION', 'test')
+    os.environ.setdefault('KEILA_ENV', 'test')
+    yield
+    if os.path.exists(config):
+        os.remove(config)
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    import main
+    return TestClient(main.app)

--- a/tests/test_action_voiceprompt.py
+++ b/tests/test_action_voiceprompt.py
@@ -1,0 +1,38 @@
+import sys
+import types
+
+from state.state_manager import StateManager
+
+
+def test_start_action_voiceprompt(monkeypatch):
+    if 'pyaudio' not in sys.modules:
+        dummy = types.ModuleType('pyaudio')
+        dummy.paInt16 = 8
+        class PyAudio:
+            def open(self, *args, **kwargs):
+                class Stream:
+                    def read(self, *a, **kw):
+                        return b''
+                    def stop_stream(self):
+                        pass
+                    def close(self):
+                        pass
+                return Stream()
+            def get_sample_size(self, *args):
+                return 2
+            def terminate(self):
+                pass
+        dummy.PyAudio = PyAudio
+        sys.modules['pyaudio'] = dummy
+
+    from Actions.VoicePrompt.VoicePrompt import start_action_VoicePrompt
+
+    monkeypatch.setattr('Actions.VoicePrompt.VoicePrompt.record_audio_untill_silence',
+                        lambda *args, **kwargs: 'tmp.wav')
+    monkeypatch.setattr('Actions.VoicePrompt.VoicePrompt.SpeechToText',
+                        lambda *args, **kwargs: 'hello')
+
+    sm = StateManager()
+    dummy_event = type('E', (), {'is_set': lambda self: False})()
+    start_action_VoicePrompt(dummy_event, sm)
+    assert sm.get_state() == 'READY'

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,23 @@
+import time
+from bib.threadManager import ThreadManager
+from state.state_manager import StateManager, state_type
+
+
+def test_state_manager():
+    sm = StateManager()
+    sm.set_state(state_type.READY)
+    assert sm.get_state() == 'READY'
+
+
+def worker(stop_event):
+    while not stop_event.is_set():
+        time.sleep(0.01)
+
+
+def test_thread_manager_start_and_stop():
+    tm = ThreadManager()
+    t = tm.start_thread('w', worker)
+    assert tm.is_running('w') is True
+    tm.stop_thread('w')
+    t.join(timeout=0.2)
+    assert not tm.is_running('w')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,43 @@
+import json
+from state.state_manager import state_type
+import main
+
+
+def test_get_info(client):
+    main.global_STATE.set_state(state_type.READY)
+    resp = client.get('/api/getInfo')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['statusCode'] == 'OK'
+
+
+def test_reload_config(client):
+    main.global_STATE.set_state(state_type.READY)
+    config_path = 'src/keila_config.json'
+    with open(config_path, 'r') as f:
+        cfg = json.load(f)
+    cfg['language'] = 'en-US'
+    with open(config_path, 'w') as f:
+        json.dump(cfg, f)
+
+    resp = client.post('/api/reloadConfig')
+    assert resp.status_code == 200
+    from bib.config import KeilaConfig
+    assert KeilaConfig.instance().get('language') == 'en-US'
+
+
+def test_action_voiceprompt_route(client, monkeypatch):
+    main.global_STATE.set_state(state_type.READY)
+    monkeypatch.setattr('main.thread_manager_main.start_thread', lambda *a, **k: None)
+    resp = client.post('/api/actions/VoicePrompt')
+    assert resp.status_code == 200
+    assert resp.json()['statusCode'] == 'OK'
+
+
+def test_cancel_actions(client, monkeypatch):
+    main.global_STATE.set_state(state_type.READY)
+    monkeypatch.setattr('main.thread_manager_main.stop_all', lambda *a, **k: None)
+    resp = client.post('/api/cancelActions')
+    assert resp.status_code == 200
+    assert resp.json()['statusCode'] == 'OK'
+    assert resp.json()['global_STATE'] == state_type.READY.name


### PR DESCRIPTION
## Summary
- add dummy pyaudio module and helper fixtures
- test main FastAPI routes
- test VoicePrompt action with patched dependencies
- test StateManager and ThreadManager components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68635e1e58ec83209672df4223f8e963